### PR TITLE
lnd: don't error if peer is already connected

### DIFF
--- a/lnd_node.go
+++ b/lnd_node.go
@@ -418,6 +418,11 @@ func (n *LndNode) ConnectPeer(peer LightningNode) {
 			Host:   fmt.Sprintf("%s:%d", peer.Host(), peer.Port()),
 		},
 	})
+
+	if err != nil && strings.Contains(err.Error(), "already connected to peer") {
+		return
+	}
+
 	CheckError(n.harness.T, err)
 }
 


### PR DESCRIPTION
Fixes lspd integration tests where we call ConnectPeer when sometimes the peer is already connected.